### PR TITLE
Fix --debug and --debug-brk options

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -31,8 +31,8 @@ app
 app
   .command('start [directory]')
   .description('Start the project in this or the specified directory')
-  .option('-d, --debug <port>', 'start in remote debug mode')
-  .option('-b, --debug-brk <port>', 'start in remote debug mode, wait for debugger connect')
+  .option('-d, --debug [port]', 'start in remote debug mode')
+  .option('-b, --debug-brk [port]', 'start in remote debug mode, wait for debugger connect')
   .option('-m, --mock', 'start in mock mode')
   .option('-o, --open', 'open browser as client to the project')
   .action(execute(project.start));

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -109,20 +109,23 @@ function start(directory, options, cb) {
     emit('Starting: %s...', fullPath);
     var nodemonOpts = {
       script: project.api.main,
-      ext: 'js,json,yaml,coffee'
+      ext: 'js,json,yaml,coffee',
+      nodeArgs: []
     };
     if (project.dirname) { nodemonOpts.cwd = project.dirname; }
     if (options.debugBrk) {
-      nodemonOpts.nodeArgs = '--debug-brk';
-      if (typeof(options.debugBrk == 'String')) {
-        nodemonOpts.nodeArgs += '=' + options.debugBrk;
+      var debugBrkArg = '--debug-brk';
+      if (typeof options.debugBrk === 'string') {
+        debugBrkArg += '=' + options.debugBrk;
       }
+      nodemonOpts.nodeArgs.push(debugBrkArg);
     }
     if (options.debug) {
-      nodemonOpts.nodeArgs = '--debug';
-      if (typeof(options.debug == 'String')) {
-        nodemonOpts.nodeArgs += '=' + options.debug;
+      var debugArg = '--debug';
+      if (typeof options.debug === 'string') {
+        debugArg += '=' + options.debug;
       }
+      nodemonOpts.nodeArgs.push(debugArg);
     }
     // https://www.npmjs.com/package/cors
     nodemonOpts.env = {

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -175,7 +175,7 @@ describe('project', function() {
       var options = { debug: 'true,test' };
       project.start(projPath, options, function(err) {
         should.not.exist(err);
-        nodemonOpts.nodeArgs.should.containDeep('--debug=' + options.debug);
+        nodemonOpts.nodeArgs.should.containDeep(['--debug=' + options.debug]);
         done();
       });
     });
@@ -184,7 +184,7 @@ describe('project', function() {
       var options = { debugBrk: true };
       project.start(projPath, options, function(err) {
         should.not.exist(err);
-        nodemonOpts.nodeArgs.should.containDeep('--debug-brk');
+        nodemonOpts.nodeArgs.should.containDeep(['--debug-brk']);
         done();
       });
     });


### PR DESCRIPTION
Make ports optional (just like for node itself).
Pass the node arguments as an array to nodemon.

This prepares for a cleaner implementation of PR #238
